### PR TITLE
Fixing wrapper by SyntaxNetWrapper [Well-known issues]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
-LABEL maintainer="mathias@short-edition.com"
+LABEL maintainer="bahri@atmatech.net"
 LABEL version="0.1"
 LABEL description="Dockerfile intending to install syntaxnet syntactic parser and its python wrapper"
 
@@ -43,7 +43,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
 ENV BAZELRC /root/.bazelrc
 
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.4.5
+ENV BAZEL_VERSION 0.4.3
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/syntaxnet_wrapper/config.yml.dist
+++ b/syntaxnet_wrapper/config.yml.dist
@@ -1,5 +1,5 @@
 syntaxnet:
-    ROOT_DIR: /root/syntaxnet
+    ROOT_DIR: /root/models/syntaxnet
     PARSER_EVAL: bazel-bin/syntaxnet/parser_eval
     CONTEXT: syntaxnet/models/parsey_universal/context.pbtxt
     MODEL: syntaxnet/models/parsey_universal


### PR DESCRIPTION
- i think the problem is bazel version. i'm try to used bazel version 0.4.3 and currently working as well for parsing with python code by python bash
- docker file update to ubuntu 16.04 LTS, and changes bazel version to 0.4.3
- config.yml for ROOT_DIR changes to /root/models/syntaxnet because at dockerfile syntaxnet be place at /root/models/